### PR TITLE
Numerical ordering and abstract collecting

### DIFF
--- a/lib/puppet/type/file_fragment.rb
+++ b/lib/puppet/type/file_fragment.rb
@@ -10,15 +10,16 @@ module Puppet
     end
 
     newparam(:target) do
-      desc "Deprecated. Use *path* instead."
+      desc "TODO"
+
+      # Can be removed after +path+ isn't in use anymore
+      defaultto do
+        resource.value(:path)
+      end
     end
 
     newparam(:path) do
-      desc "TODO"
-
-      defaultto do
-	resource.value(:target)
-      end
+      desc "Deprecated. Use *target* instead."
     end
 
     newparam(:content) do
@@ -37,7 +38,6 @@ module Puppet
       validate do |val|
         fail Puppet::ParseError "only integers > 0 are allowed and not '#{val}'" if val !~ /^\d+$/
       end
-
     end
 
     validate do


### PR DESCRIPTION
- fragments are now order by the :order _number_ instead
  of an alpha based ordering (also available in the actual
  concat module from R.I.P.)
- fragments can now use an abstract target name which is mapped
  to the name of the file_concat type (inspired by Richard Pijnenburg
  and then used the same approach as the actual concat module is
  using):
  - file_fragment's +path+ is now deprecated and +target+ should be used
